### PR TITLE
'self' config not take effect

### DIFF
--- a/include/controller/ControllerBase.class.php
+++ b/include/controller/ControllerBase.class.php
@@ -543,8 +543,12 @@ abstract class GitPHP_ControllerBase
 		if ($this->config->GetValue('graphs'))
 			$this->tpl->assign('enablegraphs', true);
 
-		$this->tpl->assign('baseurl', GitPHP_Util::BaseUrl());
-
+                if ($this->config->GetValue('self')) {
+                        $this->tpl->assign('baseurl', $this->config->GetValue('self'));
+                } else {
+                        $this->tpl->assign('baseurl', GitPHP_Util::BaseUrl());
+                }
+                
 		$requesturl = $_SERVER['REQUEST_URI'];
 		$querypos = strpos($requesturl, '?');
 		if ($querypos !== false)


### PR DESCRIPTION
even if $gitphp_conf['self'] was set, css resource file still get wrong path.

e.g.  when I set 'self' to  'http://git.reactshare.cn/', I still get css url path as http://git.reactshare.cn/git/css/gitphpskin.css, while http://git.reactshare.cn/css/gitphpskin.css is expected.


```php
$gitphp_conf['self'] = 'http://git.reactshare.cn/';
```